### PR TITLE
Adopt shared Scala CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,46 +7,9 @@ on:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        scala:
-          - 2.13.18
-          - 3.3.7
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: coursier/cache-action@v6
-
-      - name: setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'oracle'
-          cache: 'sbt'
-
-      - name: setup SBT
-        uses: sbt/setup-sbt@v1
-
-      - name: check code ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean check
-
-      - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
-
-      - name: test coverage
-        if: success()
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
-
-      - name: slack
-        uses: homoluctus/slatify@master
-        if: failure() && github.ref == 'refs/heads/master'
-        with:
-          type: ${{ job.status }}
-          job_name: Build
-          url: ${{ secrets.SLACK_WEBHOOK }}
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
+    secrets: inherit
+    with:
+      scala_versions: '["2.13.18", "3.3.7"]'
+      # TODO no sbt-scalafmt in this repo, so formatting was never checked
+      scalafmt_check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
     with:
       scala_versions: '["2.13.18", "3.3.7"]'
       # TODO no sbt-scalafmt in this repo, so formatting was never checked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
-    secrets: inherit
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
     with:
       scala_versions: '["2.13.18", "3.3.7"]'
       # TODO no sbt-scalafmt in this repo, so formatting was never checked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@dde27b9bd793d41d5aacf8fb74403c9de5da1146 # v6.3.0
     with:
       scala_versions: '["2.13.18", "3.3.7"]'
       # TODO no sbt-scalafmt in this repo, so formatting was never checked

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")


### PR DESCRIPTION
Replaces the hand-written ci.yml with a call to the shared workflow, so tests, coverage, binary compatibility, formatting and scaladoc are configured centrally. Same for scalafmt. Also drops the Slack step, which used the archived slatify action.

Checks now run as explicit sbt tasks rather than through the `check` alias, and checkout is unshallow so versionPolicyCheck has a previous version to compare against.

Part of evolution-gaming/scala-github-actions#5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow to test against Scala 2.13.18 and 3.3.7.
  * Streamlined automated build validation by using the shared CI workflow.
  * Replaced Coveralls integration with Scoverage-based code coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->